### PR TITLE
Correct findInterval - needs vec that is sorted non-decreasingly

### DIFF
--- a/R/calc_timingAverage.R
+++ b/R/calc_timingAverage.R
@@ -69,7 +69,7 @@ calc_timingAverage <- function(x,yearType = "water",digits=3,pref="mean",floodTh
 
         #...using findInterval
         break_pts = c(.1, seq(0.25, 2.25, by=.25)) * log_meanFlow
-        x$interv = findInterval(x$log_discharge, break_pts)
+        x$interv = findInterval(x$log_discharge, sort(break_pts))
         colwellMatrix = table(x$day, x$interv)
         
         #ta1.2


### PR DESCRIPTION
If discharge values are low and then log-transformed, all values will be negative and thus ordered decreasingly, throwing the following error:
Error in findInterval(x$log_discharge, break_pts) : 
  'vec' must be sorted non-decreasingly and not contain NAs"
Which stops the calc_allHIT computation.
It could be solved by simply adding:
x$interv = findInterval(x$log_discharge, sort(break_pts))